### PR TITLE
example: run nfsidmap in ssd container

### DIFF
--- a/id_resolver.conf.sample
+++ b/id_resolver.conf.sample
@@ -1,0 +1,1 @@
+create	id_resolver	*	*	/usr/bin/run_in_sssd_container /usr/sbin/nfsidmap -t 600 %k %d

--- a/run_in_sssd_container
+++ b/run_in_sssd_container
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Run's a command in the SSSD container.
+#
+# Designed for use with request-key(8). Example uncontainerized request-key
+# config:
+#   create id_resolver * * /usr/sbin/nfsidmap -t 600 %k %d
+#
+# To containerize, change config to:
+#   create id_resolver * * in_sssd_container /usr/sbin/nfsidmap -t 600 %k %d
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+declare -r SSSD_PATH="/usr/bin/sssd"
+
+sssd_pid=$(pgrep -nxf "${SSSD_PATH} .*") || {
+  >&2 echo "Failed to find process ID for SSSD. Is '${SSSD_PATH}' the right arg0 for the SSSD process?"
+  exit 1
+}
+
+exec nsenter --target "${sssd_pid}" --all "${@}"


### PR DESCRIPTION
To setup:
1. install nfsidmap and libnss-sss packages in sssd container image.
2. replace /etc/request-key.d/id_resolver.conf with id_resolver.conf.sample on host
3. move run_in_sssd_container into /usr/bin/ on host

To test, run e.g. `sudo /usr/bin/run_in_sssd_container ps`.